### PR TITLE
Add static file support for playground courses plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	manager        *gitsync.SyncManager
+	manager *gitsync.SyncManager
 )
 
 func init() {


### PR DESCRIPTION
Server the whole directory of "courses" in playground courses repo as API endpoints.